### PR TITLE
fix: wrong method name

### DIFF
--- a/websocket/main.go
+++ b/websocket/main.go
@@ -21,7 +21,7 @@ func main() {
 			c.Locals("Host", "Localhost:3000")
 			return c.Next()
 		}
-		return c.Status(403).Send("Request origin not allowed")
+		return c.Status(403).SendString("Request origin not allowed")
 	})
 
 	// Upgraded websocket request


### PR DESCRIPTION
Should be `SendString()` in version 2