### PR TITLE
Add termination signal for graceful shutdown

### DIFF
--- a/graceful-shutdown/main.go
+++ b/graceful-shutdown/main.go
@@ -24,7 +24,7 @@ func main() {
 	}()
 
 	c := make(chan os.Signal, 1)   // Create channel to signify a signal being sent
-	signal.Notify(c, os.Interrupt) // When an interrupt is sent, notify the channel
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM) // When an interrupt or termination signal is sent, notify the channel
 
 	_ = <-c // This blocks the main thread until an interrupt is received
 	fmt.Println("Gracefully shutting down...")


### PR DESCRIPTION
When deployed in a container (and e.g. in a K8s cluster), the signal for a shutdown usually is SIGTERM. I would add this to the recipe because I think this is a very common use case. Btw I absolutely love fiber! Keep up the good work :)