### PR TITLE
Fix missing stage name

### DIFF
--- a/k8s/Dockerfile
+++ b/k8s/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang
+FROM golang AS builder
 WORKDIR /k8s-example
 COPY go.mod .
 COPY go.sum .
@@ -10,6 +10,6 @@ FROM alpine:latest
 RUN addgroup -S k8s-example && adduser -S k8s-example -G k8s-example
 USER k8s-example
 WORKDIR /home/k8s-example
-COPY --from=build-go /bin/k8s-example ./
+COPY --from=builder /bin/k8s-example ./
 EXPOSE 3000
 ENTRYPOINT ["./k8s-example"]


### PR DESCRIPTION
The copy origin in line 13 should be either `0` or stage 0 should be annotated with `AS builder`, otherwise this build leads to an error.