### PR TITLE
Install ca-certificates to be able to use TLS

### DIFF
--- a/k8s/Dockerfile
+++ b/k8s/Dockerfile
@@ -7,6 +7,7 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /bin/k8s-example .
 
 FROM alpine:latest
+RUN apk --no-cache add ca-certificates
 RUN addgroup -S k8s-example && adduser -S k8s-example -G k8s-example
 USER k8s-example
 WORKDIR /home/k8s-example


### PR DESCRIPTION
The ca-certificates are necessary to establish TLS encrypted connections with the HTTP client or other TCP connection e.g. to a database. Although they are not required in this particular example, I believe that many will still run into this problem. The Docker best practices documentation about [multi-stage builds](https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds) also adds the certificates.