### PR TITLE
Removing duplicate colon in address in main.go under websocket-chat

### DIFF
--- a/websocket-chat/main.go
+++ b/websocket-chat/main.go
@@ -90,5 +90,5 @@ func main() {
 
 	addr := flag.String("addr", ":8080", "http service address")
 	flag.Parse()
-	log.Fatal(app.Listen(":" + *addr))
+	log.Fatal(app.Listen(*addr))
 }


### PR DESCRIPTION
removing duplicate colon to address.

Following error while running the application : 
_listen tcp4: address ::8080: too many colons in address_
