### PR TITLE
fixing socket

### DIFF
--- a/websocket-chat/main.go
+++ b/websocket-chat/main.go
@@ -30,8 +30,9 @@ func runHub() {
 				if err := connection.WriteMessage(websocket.TextMessage, []byte(message)); err != nil {
 					log.Println("write error:", err)
 
-					unregister <- connection
-					connection.WriteMessage(websocket.CloseMessage, []byte{})
+					//unregister <- connection
+					//connection.WriteMessage(websocket.CloseMessage, []byte{})
+					delete(clients, connection)
 					connection.Close()
 				}
 			}


### PR DESCRIPTION
Firefox will trigger `write error: websocket: close sent` (chromium seems to be unable to trigger this event, even with thousands of refreshes sent) by pressing refresh several times on a page with a load time of (network latency included) >250ms 
This causes the `unregister <- connection` to fire, however this breaks the socket entirely for ALL current connections and all future connections will connect to the websocket but the websocket is down and will not transfer / receive messages. (Messages can be sent to the server ACCORDING TO THE BROWSER but without error but they're thrown out by the server without notice of any kind).

No idea why it happens like that, but it does. Posted fix works fine.