### PR TITLE
Add timeout for handling keep-alive clients

### DIFF
--- a/graceful-shutdown/main.go
+++ b/graceful-shutdown/main.go
@@ -10,11 +10,11 @@ import (
 	"time"
 )
 
-const IdleTimeout = 5 * time.Second
+const idleTimeout = 5 * time.Second
 
 func main() {
 	app := fiber.New(fiber.Config{
-		IdleTimeout: IdleTimeout,
+		IdleTimeout: idleTimeout,
 	})
 
 	app.Get("/", func(c *fiber.Ctx) error {

--- a/graceful-shutdown/main.go
+++ b/graceful-shutdown/main.go
@@ -7,10 +7,15 @@ import (
 	"os/signal"
 	"syscall"
 	"github.com/gofiber/fiber/v2"
+	"time"
 )
 
+const IdleTimeout = 5 * time.Second
+
 func main() {
-	app := fiber.New()
+	app := fiber.New(fiber.Config{
+		IdleTimeout: IdleTimeout,
+	})
 
 	app.Get("/", func(c *fiber.Ctx) error {
 		return c.SendString("Hello world!")
@@ -35,5 +40,5 @@ func main() {
 	// Your cleanup tasks go here
 	// db.Close()
 	// redisConn.Close()
-
+	fmt.Println("Fiber was successful shutdown.")
 }


### PR DESCRIPTION
If we use keep-alive clients like a Postman or other clients with keep-alive headers, the Fiber server will be never shutdown.
I suggest adding the IdleTimeout because by default this value is infinity.
Also, I add 

```
fmt.Println("Fiber was successful shutdown.")
```