### PR TITLE
👷 Fix deadlock in websocket-chat recipe

### DIFF
--- a/websocket-chat/main.go
+++ b/websocket-chat/main.go
@@ -30,9 +30,9 @@ func runHub() {
 				if err := connection.WriteMessage(websocket.TextMessage, []byte(message)); err != nil {
 					log.Println("write error:", err)
 
-					unregister <- connection
 					connection.WriteMessage(websocket.CloseMessage, []byte{})
 					connection.Close()
+					delete(clients, connection)
 				}
 			}
 


### PR DESCRIPTION
Now in the websocket-chat recipe, `unregister = make(chan *websocket.Conn)`, so it's a blocked channel.

In the broadcast case, if we fail to send message to a client, we can't unregister the client by `unregister <- connection`, which will cause deadlock.
```go
case message := <-broadcast:
	log.Println("message received:", message)

	// Send the message to all clients
	for connection := range clients {
		if err := connection.WriteMessage(websocket.TextMessage, []byte(message)); err != nil {
			log.Println("write error:", err)

			unregister <- connection
			connection.WriteMessage(websocket.CloseMessage, []byte{})
			connection.Close()
		}
	}

case connection := <-unregister:
	// Remove the client from the hub
	delete(clients, connection)

	log.Println("connection unregistered")
}
```

Instead, we need to delete it from `clients` directly.