### PR TITLE
Fix broken `unit-test` example

### DIFF
--- a/unit-test/main_test.go
+++ b/unit-test/main_test.go
@@ -36,7 +36,7 @@ func TestIndexRoute(t *testing.T) {
 			route:         "/i-dont-exist",
 			expectedError: false,
 			expectedCode:  404,
-			expectedBody:  "Not Found",
+			expectedBody:  "Cannot GET /i-dont-exist",
 		},
 	}
 


### PR DESCRIPTION
The body is a combination of HTTP method + path now.
https://github.com/gofiber/fiber/blob/9b3662eae0e348892e28780b001ec146bc33be36/router.go#L133