### PR TITLE
Fix confusing behaviors for newbie in the clean-architecture recipe

### DIFF
--- a/clean-architecture/api/app.go
+++ b/clean-architecture/api/app.go
@@ -5,12 +5,13 @@ import (
 	"clean-architecture/pkg/book"
 	"context"
 	"fmt"
+	"log"
+	"time"
+
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/fiber/v2/middleware/cors"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
-	"log"
-	"time"
 )
 
 func main() {
@@ -30,7 +31,7 @@ func main() {
 	})
 	api := app.Group("/api")
 	routes.BookRouter(api, bookService)
-	_ = app.Listen(":8080")
+	log.Fatal(app.Listen(":8080"))
 
 }
 

--- a/clean-architecture/api/app.go
+++ b/clean-architecture/api/app.go
@@ -37,7 +37,7 @@ func main() {
 
 func DatabaseConnection() (*mongo.Database, error) {
 	ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
-	client, err := mongo.Connect(ctx, options.Client().ApplyURI("mongodb://username:password@localhost:27017/fiber"))
+	client, err := mongo.Connect(ctx, options.Client().ApplyURI("mongodb://username:password@localhost:27017/fiber").SetServerSelectionTimeout(5*time.Second))
 	if err != nil {
 		return nil, err
 	}

--- a/clean-architecture/api/routes/book.go
+++ b/clean-architecture/api/routes/book.go
@@ -3,6 +3,7 @@ package routes
 import (
 	"clean-architecture/pkg/book"
 	"clean-architecture/pkg/entities"
+
 	"github.com/gofiber/fiber/v2"
 )
 
@@ -77,15 +78,19 @@ func removeBook(service book.Service) fiber.Handler {
 func getBooks(service book.Service) fiber.Handler {
 	return func(c *fiber.Ctx) error {
 		fetched, err := service.FetchBooks()
+		var result fiber.Map
 		if err != nil {
-			_ = c.JSON(&fiber.Map{
+			result = fiber.Map{
 				"status": false,
-				"error":  err,
-			})
+				"error":  err.Error(),
+			}
+		} else {
+			result = fiber.Map{
+				"status": true,
+				"books":  fetched,
+			}
 		}
-		return c.JSON(&fiber.Map{
-			"status": true,
-			"books":  fetched,
-		})
+
+		return c.JSON(&result)
 	}
 }


### PR DESCRIPTION
Hi!

Thanks for your excellent work. I'm new to both Go and Go Fiber and when I was trying to run the "clean-architecture" recipe, I found these problems:

1. The server did not start and the app just exited without any error. It turned out that the port "8080" was already in use.
2. I made a request to the `GET /api/books` endpoint and the server took roughly about 20 seconds to respond because the Mongo client could not connect to the database server and there's no error about it neither in the response payload nor the stderr.

### Solutions

For problem 1., I fix it by wrapping the `app.Listen()` with the `log.Fatal()` in [
a2deee6](https://github.com/gofiber/recipes/commit/a2deee6904c6cef7bee9cb2ef452503b6cac834b).
And for problem 2., I make it to respond with the error message in the response payload when there's an error occur in [
c717b09](https://github.com/gofiber/recipes/commit/c717b092eb8650afe3908f55b4a27d4568cfb0b9). And also make it fails early when there's a problem connecting with a database server by setting the `options.Client().SetServerSelectionTimeout()` in [
2b10041](https://github.com/gofiber/recipes/commit/2b1004110d2ae32ccd7fd5cf99c535f49892646c)

As a Go newbie, it took me hours to debug those problems. So, I create this PR in hope that it helps save someone's time in the future.