### PR TITLE
Fix Markdown Link

### DIFF
--- a/auth-jwt/README.md
+++ b/auth-jwt/README.md
@@ -1,6 +1,6 @@
 # Fiber with Auth
 
-(Postman collection)[https://www.getpostman.com/collections/c862d012d5dcf50326f7]
+[Postman collection](https://www.getpostman.com/collections/c862d012d5dcf50326f7)
 
 ## Endpoints
 


### PR DESCRIPTION
Fixed a small Markdown syntax error regarding the Link in the auth-jqt/README.md file