### PR TITLE
Update graphql example for compatibility with 99designs/gqlgen package

### DIFF
--- a/graphql/graph/generated/generated.go
+++ b/graphql/graph/generated/generated.go
@@ -10,8 +10,8 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/arsmn/fastgql/graphql"
-	"github.com/arsmn/fastgql/graphql/introspection"
+	"github.com/99designs/gqlgen/graphql"
+	"github.com/99designs/gqlgen/graphql/introspection"
 	"github.com/gofiber/recipes/graphql/graph/model"
 	gqlparser "github.com/vektah/gqlparser/v2"
 	"github.com/vektah/gqlparser/v2/ast"

--- a/graphql/server.go
+++ b/graphql/server.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"log"
+	"net/http"
 	"os"
 
 	"github.com/99designs/gqlgen/graphql/handler"

--- a/graphql/server.go
+++ b/graphql/server.go
@@ -4,11 +4,12 @@ import (
 	"log"
 	"os"
 
-	"github.com/arsmn/fastgql/graphql/handler"
-	"github.com/arsmn/fastgql/graphql/playground"
+	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/99designs/gqlgen/graphql/playground"
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/recipes/graphql/graph"
 	"github.com/gofiber/recipes/graphql/graph/generated"
+	"github.com/valyala/fasthttp/fasthttpadaptor"
 )
 
 const defaultPort = "8080"
@@ -23,16 +24,18 @@ func main() {
 
 	srv := handler.NewDefaultServer(generated.NewExecutableSchema(generated.Config{Resolvers: &graph.Resolver{}}))
 
-	gqlHandler := srv.Handler()
+	gqlHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		srv.ServeHTTP(w, r)
+	})
 	playground := playground.Handler("GraphQL playground", "/query")
 
 	app.All("/query", func(c *fiber.Ctx) error {
-		gqlHandler(c.Context())
+		fasthttpadaptor.NewFastHTTPHandler(gqlHandler)(c.Context())
 		return nil
 	})
 
 	app.All("/", func(c *fiber.Ctx) error {
-		playground(c.Context())
+		fasthttpadaptor.NewFastHTTPHandler(playground)(c.Context())
 		return nil
 	})
 


### PR DESCRIPTION
These changes allow this example to work with the [https://github.com/99designs/gqlgen](https://github.com/99designs/gqlgen) package