### PR TITLE
fix: remove unreachable os.Exit function

### DIFF
--- a/gorm-postgres/database/database.go
+++ b/gorm-postgres/database/database.go
@@ -26,7 +26,6 @@ func ConnectDb() {
 
 	if err != nil {
 		log.Fatal("Failed to connect to database. \n", err)
-		os.Exit(2)
 	}
 
 	log.Println("connected")


### PR DESCRIPTION
on this error handling, there's no need to use os.Exit() function; because log.Fatal() already use os.Exit()
This os.Exit() is unreachable.