### PR TITLE
Should omit comparison to bool constant in auth-jwt/handler/auth.go

### DIFF
--- a/auth-jwt/handler/auth.go
+++ b/auth-jwt/handler/auth.go
@@ -73,7 +73,7 @@ func Login(c *fiber.Ctx) error {
 	pass := input.Password
 	user, email, err := new(model.User), new(model.User), *new(error)
 
-	if valid(identity) == true {
+	if valid(identity) {
 		email, err = getUserByEmail(identity)
 		if err != nil {
 			return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"status": "error", "message": "Error on email", "data": err})


### PR DESCRIPTION
`auth-jwt/handler/auth.go`
Should omit comparison to bool constant, can be simplified to valid(identity) as it is returning **bool**

```go
// From
if valid(identity) == true {

}

// To
if valid(identity) {

}
```