### PR TITLE
fixing `/bin/sh: application not found`

### DIFF
--- a/air/.air.linux.conf
+++ b/air/.air.linux.conf
@@ -11,7 +11,7 @@ cmd = "go build -o ./application ./main.go"
 # Binary file yields from `cmd`.
 bin = "application"
 # Customize binary.
-full_bin = "application"
+full_bin = "./application"
 # Watch these filename extensions.
 include_ext = ["go", "tpl", "tmpl", "html", "mustache", "hbs", "pug"]
 # Ignore these filename extensions or directories.


### PR DESCRIPTION
Little fix to avoid this error:
![image](https://user-images.githubusercontent.com/67751668/203409618-708c1a5c-f502-48af-b79a-d0bec2fd41bb.png)
