### PR TITLE
FIX: swagger initialization in swagger Example

### DIFF
--- a/swagger/routes/routes.go
+++ b/swagger/routes/routes.go
@@ -19,7 +19,7 @@ func New() *fiber.App {
 		TimeZone:   "Asia/Jakarta",
 	}))
 
-	app.Get("/docs/*", swagger.Handler)
+	app.Get("/docs/*", swagger.HandlerDefault)
 	api := app.Group("/api")
 	v1 := api.Group("/v1", func(c *fiber.Ctx) error {
 		c.JSON(fiber.Map{


### PR DESCRIPTION
While working on the project, I discovered an issue in the 'routes.go' file in the swagger example where the Swagger Handler method was not correctly referenced.

Changes
There is a change on line 20 of the 'routes.go' file. The incorrect usage of 'Handler' was replaced with 'HandlerDefault', as documented in the official [Fiber Swagger package](https://pkg.go.dev/github.com/arsmn/fiber-swagger/v2#section-readme).

- app.Get ("/docs/*", swagger. Handler)
+ app.Get ("/docs/*", swagger. HandlerDefault)