### PR TITLE
fix(Recipes): auth-jwt-login bug not returning nil if user not found

### DIFF
--- a/auth-docker-postgres-jwt/handler/auth.go
+++ b/auth-docker-postgres-jwt/handler/auth.go
@@ -26,7 +26,7 @@ func CheckPasswordHash(password, hash string) bool {
 func getUserByEmail(e string) (*model.User, error) {
 	db := database.DB
 	var user model.User
-	if err := db.Where(&model.User{Email: e}).Find(&user).Error; err != nil {
+	if err := db.Where(&model.User{Email: e}).First(&user).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil
 		}
@@ -38,7 +38,7 @@ func getUserByEmail(e string) (*model.User, error) {
 func getUserByUsername(u string) (*model.User, error) {
 	db := database.DB
 	var user model.User
-	if err := db.Where(&model.User{Username: u}).Find(&user).Error; err != nil {
+	if err := db.Where(&model.User{Username: u}).First(&user).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil
 		}

--- a/auth-jwt/handler/auth.go
+++ b/auth-jwt/handler/auth.go
@@ -25,7 +25,7 @@ func CheckPasswordHash(password, hash string) bool {
 func getUserByEmail(e string) (*model.User, error) {
 	db := database.DB
 	var user model.User
-	if err := db.Where(&model.User{Email: e}).Find(&user).Error; err != nil {
+	if err := db.Where(&model.User{Email: e}).First(&user).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil
 		}
@@ -37,7 +37,7 @@ func getUserByEmail(e string) (*model.User, error) {
 func getUserByUsername(u string) (*model.User, error) {
 	db := database.DB
 	var user model.User
-	if err := db.Where(&model.User{Username: u}).Find(&user).Error; err != nil {
+	if err := db.Where(&model.User{Username: u}).First(&user).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil
 		}


### PR DESCRIPTION
**Why?** 

Instead of returning "User not found", "Invalid password" is displayed when calling `getUserByEmail` or `getUserByUsername` and the user is not found in the database.

Related issue: 
Fixes #2212 

**What?**

This PR updates the database query in the `getUserByEmail` and `getUserByUsername` to use First() instead of Find() when looking up a single user record. 


**Tests:**
 

<img width="442" alt="Screenshot 2024-01-21 at 5 44 57 PM" src="https://github.com/gofiber/recipes/assets/54759476/d59852ae-2071-4fbc-99a3-9f984764b441">

<img width="507" alt="Screenshot 2024-01-21 at 5 45 06 PM" src="https://github.com/gofiber/recipes/assets/54759476/34490d92-7863-4b54-9bc9-35caff2b5052">


