### PR TITLE
fix: route mismatch in GeoIP example due to incorrect path and query

### DIFF
--- a/geoip/handlers/geo.go
+++ b/geoip/handlers/geo.go
@@ -15,8 +15,8 @@ func GEO() fiber.Handler {
 
 	// Return handler
 	return func(c *fiber.Ctx) error {
-		// Get domain from param else default to remote IP
-		ip := c.Query("ip")
+		// Get domain from query string, else default to remote IP
+		ip := c.Query("ip", c.IP())
 
 		// Get request/response from pool
 		req := fasthttp.AcquireRequest()

--- a/geoip/handlers/geo.go
+++ b/geoip/handlers/geo.go
@@ -16,7 +16,7 @@ func GEO() fiber.Handler {
 	// Return handler
 	return func(c *fiber.Ctx) error {
 		// Get domain from param else default to remote IP
-		ip := c.Params("ip", c.IP())
+		ip := c.Query("ip")
 
 		// Get request/response from pool
 		req := fasthttp.AcquireRequest()

--- a/geoip/main.go
+++ b/geoip/main.go
@@ -30,7 +30,7 @@ func main() {
 	})
 
 	// Main GEO handler that is cached for 10 minutes
-	app.Get("/geo/:ip?", handlers.Cache(10*time.Minute), handlers.GEO())
+	app.Get("/geo", handlers.Cache(10*time.Minute), handlers.GEO())
 
 	// Handle 404 errors
 	app.Use(handlers.NotFound("./public/404.html"))


### PR DESCRIPTION
Why? 
geoip example ,the route in the page request does not match the route in the code


What? 
- replaced route to handle route `/geo` instead of `/geo/:ip?`
- replaced Params with [Query](https://docs.gofiber.io/api/ctx#query) to retrieve the ip

![image](https://github.com/gofiber/recipes/assets/54759476/5078ec98-fb15-4dd7-bc29-a9341e9d8019)



Fixes #2222 