### PR TITLE
chore(Recipes): Update AWS Lambda Go Runtime to Amazon Linux 2023 and Revise README for URL Permissions

### DIFF
--- a/aws-sam-container/README.md
+++ b/aws-sam-container/README.md
@@ -60,6 +60,31 @@ The command will package and deploy your application to AWS, with a series of pr
 
 You can find your API Gateway Endpoint URL in the output values displayed after deployment.
 
+## Add Permission to the Lambda Function for Public Access
+
+After deploying your Lambda function with an associated function URL, you might encounter a scenario where the function URL is not accessible due to missing permissions for public access. This is common when the authentication type for the function URL is set to "None," indicating that the function is intended to be publicly accessible without authentication.
+
+To ensure your Lambda function URL can be invoked publicly, you need to add the necessary permission that allows unauthenticated requests. This step is crucial when your function URL's authentication type is "None" but lacks the requisite permissions for public invocation.
+
+Manually Configuring Permissions
+You can manually configure permissions through the AWS Lambda console by creating a resource-based policy that grants the lambda:invokeFunctionUrl permission to all principals (*). This approach is straightforward but not suitable for automation within deployment pipelines.
+
+Automating Permission Configuration
+For a more automated approach, especially useful in CI/CD pipelines, you can use the AWS CLI or SDKs to add the necessary permissions after deploying your Lambda function. This can be incorporated into your deployment scripts or CI/CD workflows.
+
+Here is an example AWS CLI command that adds the required permission for public access to your Lambda function URL:
+
+```shell
+aws lambda add-permission \
+  --function-name <your-function-name> \
+  --action lambda:InvokeFunctionUrl \
+  --principal "*" \
+  --function-url-auth-type "NONE" \
+  --statement-id unique-statement-id
+```
+
+This command grants permission to all principals (*) to invoke your Lambda function URL, enabling public access as intended.
+
 # Appendix
 
 ### Golang installation

--- a/aws-sam-container/samconfig.toml
+++ b/aws-sam-container/samconfig.toml
@@ -7,6 +7,7 @@ version = 0.1
 stack_name = "sam-app"
 
 [default.build.parameters]
+cached = true
 parallel = true
 
 [default.validate.parameters]
@@ -16,9 +17,6 @@ lint = true
 capabilities = "CAPABILITY_NAMED_IAM"
 confirm_changeset = true
 resolve_s3 = true
-resolve_image_repos = true
-s3_prefix = "sam-app"
-region = "ap-northeast-1"
 
 [default.package.parameters]
 resolve_s3 = true

--- a/aws-sam/README.md
+++ b/aws-sam/README.md
@@ -71,6 +71,32 @@ The command will package and deploy your application to AWS, with a series of pr
 
 You can find your API Gateway Endpoint URL in the output values displayed after deployment.
 
+
+## Add Permission to the Lambda Function for Public Access
+
+After deploying your Lambda function with an associated function URL, you might encounter a scenario where the function URL is not accessible due to missing permissions for public access. This is common when the authentication type for the function URL is set to "None," indicating that the function is intended to be publicly accessible without authentication.
+
+To ensure your Lambda function URL can be invoked publicly, you need to add the necessary permission that allows unauthenticated requests. This step is crucial when your function URL's authentication type is "None" but lacks the requisite permissions for public invocation.
+
+Manually Configuring Permissions
+You can manually configure permissions through the AWS Lambda console by creating a resource-based policy that grants the lambda:invokeFunctionUrl permission to all principals (*). This approach is straightforward but not suitable for automation within deployment pipelines.
+
+Automating Permission Configuration
+For a more automated approach, especially useful in CI/CD pipelines, you can use the AWS CLI or SDKs to add the necessary permissions after deploying your Lambda function. This can be incorporated into your deployment scripts or CI/CD workflows.
+
+Here is an example AWS CLI command that adds the required permission for public access to your Lambda function URL:
+
+```shell
+aws lambda add-permission \
+  --function-name <your-function-name> \
+  --action lambda:InvokeFunctionUrl \
+  --principal "*" \
+  --function-url-auth-type "NONE" \
+  --statement-id unique-statement-id
+```
+
+This command grants permission to all principals (*) to invoke your Lambda function URL, enabling public access as intended.
+
 # Appendix
 
 ### Golang installation

--- a/aws-sam/app/go.mod
+++ b/aws-sam/app/go.mod
@@ -1,25 +1,27 @@
 require (
-	github.com/aws/aws-lambda-go v1.36.1
-	github.com/awslabs/aws-lambda-go-api-proxy v0.16.0
+	github.com/aws/aws-lambda-go v1.46.0
+	github.com/awslabs/aws-lambda-go-api-proxy v0.16.1
 	github.com/gofiber/fiber/v2 v2.52.0
 )
 
 require (
-	github.com/andybalholm/brotli v1.0.5 // indirect
-	github.com/google/uuid v1.3.1 // indirect
-	github.com/klauspost/compress v1.16.7 // indirect
+	github.com/andybalholm/brotli v1.1.0 // indirect
+	github.com/google/uuid v1.6.0 // indirect
+	github.com/klauspost/compress v1.17.6 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
-	github.com/mattn/go-isatty v0.0.19 // indirect
+	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.15 // indirect
-	github.com/rivo/uniseg v0.2.0 // indirect
+	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
-	github.com/valyala/fasthttp v1.50.0 // indirect
+	github.com/valyala/fasthttp v1.52.0 // indirect
 	github.com/valyala/tcplisten v1.0.0 // indirect
-	golang.org/x/sys v0.13.0 // indirect
+	golang.org/x/sys v0.17.0 // indirect
 )
 
 replace gopkg.in/yaml.v2 => gopkg.in/yaml.v2 v2.2.8
 
 module app
 
-go 1.19
+go 1.21
+
+toolchain go1.21.0

--- a/aws-sam/samconfig.toml
+++ b/aws-sam/samconfig.toml
@@ -17,9 +17,6 @@ lint = true
 capabilities = "CAPABILITY_NAMED_IAM"
 confirm_changeset = true
 resolve_s3 = true
-s3_prefix = "sam-app"
-region = "ap-northeast-1"
-image_repositories = []
 
 [default.package.parameters]
 resolve_s3 = true

--- a/aws-sam/template.yaml
+++ b/aws-sam/template.yaml
@@ -11,12 +11,28 @@ Globals:
     MemorySize: 256
 
 Resources:
+  LambdaFunction:
+    Type: AWS::Serverless::Function
+    Metadata:
+      BuildMethod: go1.x
+    Properties:
+      FunctionName: sam-app
+      CodeUri: app/
+      Handler: bootstrap
+      Runtime: provided.al2023
+      Architectures:
+        - x86_64
+      Role: !GetAtt LambdaFunctionRole.Arn
+      Environment:
+        Variables:
+          PARAM1: VALUE
+
   LambdaFunctionRole:
     Type: AWS::IAM::Role
     Properties:
       RoleName: sam-app-role
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/AmazonVPCFullAccess
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -34,21 +50,6 @@ Resources:
               - Effect: Allow
                 Action: 'logs:*'
                 Resource: '*'
-
-  LambdaFunction:
-    Type: AWS::Serverless::Function
-    Properties:
-      FunctionName: sam-app
-      PackageType: Zip
-      CodeUri: app/
-      Handler: cmd/Handler
-      Runtime: go1.x
-      Role: !GetAtt LambdaFunctionRole.Arn
-      Architectures:
-        - x86_64
-      Environment:
-        Variables:
-          PARAM1: VALUE
 
   LambdaFunctionUrl:
     Type: AWS::Lambda::Url


### PR DESCRIPTION
### Changes

- Runtime Update: Switched Lambda function runtime from go1.x to provided.al2023, aligning with AWS's latest support and performance enhancements.

- README Update: Added instructions for setting up public access permissions on Lambda function URLs using aws lambda add-permission.

### Rationale

These updates respond to the AWS deprecation of the Go 1.x runtime, ensuring our Lambda functions remain supported and secure. The README enhancement clarifies how to manage access permissions for function URLs, improving usability and deployment workflows.

Ref: [Migrating AWS Lambda functions from the Go1.x runtime to the custom runtime on Amazon Linux 2](https://aws.amazon.com/cn/blogs/compute/migrating-aws-lambda-functions-from-the-go1-x-runtime-to-the-custom-runtime-on-amazon-linux-2/)

Testing
Confirmed the updated runtime functions correctly and that README instructions effectively guide permission settings for function URL access.

