### PR TITLE
update air github url on dockerfile for recipe auth-docker-postgre-jwt

### DIFF
--- a/auth-docker-postgres-jwt/Dockerfile
+++ b/auth-docker-postgres-jwt/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.23.0@sha256:613a108a4a4b1dfb6923305db791a19d088f77632317cfc3446825
 # Enviroment variable
 WORKDIR /usr/src/some-api
 
-RUN go install github.com/cosmtrek/air@latest
+RUN go install github.com/air-verse/air@latest
 
 #Copying files to work directory
 COPY go.mod ./


### PR DESCRIPTION
The air repository on dockerfile is pointing to the old url which is failing when docker compose is building.
![air-dockfiler-failed](https://github.com/user-attachments/assets/ade12077-0006-4fca-9aad-3549d5e366c0)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the source of the live-reloading package to ensure continued support and functionality during development.
  
- **Chores**
	- Modified the Dockerfile to reflect the new repository for the `air` package, maintaining the overall structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->