### PR TITLE
feat(recipe/tableflip): Add Graceful shutdown to ensure continuous up…

### DIFF
--- a/tableflip/main.go
+++ b/tableflip/main.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/cloudflare/tableflip"
 	"github.com/gofiber/fiber/v2"
@@ -47,4 +49,15 @@ func main() {
 	}
 
 	<-upg.Exit()
+
+	// Make sure to set a deadline on exiting the process
+	// after upg.Exit() is closed. No new upgrades can be
+	// performed if the parent doesn't exit.
+	time.AfterFunc(30*time.Second, func() {
+		log.Println("Graceful shutdown timed out")
+		os.Exit(1)
+	})
+
+	// Wait for connections to drain.
+	app.ShutdownWithContext(context.Background())
 }


### PR DESCRIPTION
In the original Cloudflare Tableflip http example, they use a graceful shutdown method to ensure a continuous service uptime. In contrast, with the original fiber recipe, if you send the upgrade signal to the fiber process, current connections will die out (you can test with `ab -c 50 -n 100000 http://127.0.0.1:8080/version` and then send an upgrade signal while the test is running and see how the service dies). This commit fixes this issue with the original recipe and now actually allows for a continuous service uptime.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a timeout mechanism for graceful application shutdown, ensuring processes exit properly within 30 seconds.
	- Added functionality to wait for existing connections to drain before termination, improving overall stability during shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->