### PR TITLE
fix: Correct inconsistencies with oauth2-google recipe

### DIFF
--- a/oauth2-google/README.md
+++ b/oauth2-google/README.md
@@ -32,6 +32,7 @@ This example demonstrates how to implement Google OAuth2 authentication in a Fib
 
 4. Create a `.env` file in the root directory and add your Google OAuth credentials:
     ```env
+    APP_PORT=3300
     GOOGLE_CLIENT_ID=your_client_id
     GOOGLE_CLIENT_SECRET=your_client_secret
     GOOGLE_REDIRECT_URL=http://localhost:3300/api/auth/google/callback

--- a/oauth2-google/README.md
+++ b/oauth2-google/README.md
@@ -34,7 +34,7 @@ This example demonstrates how to implement Google OAuth2 authentication in a Fib
     ```env
     GOOGLE_CLIENT_ID=your_client_id
     GOOGLE_CLIENT_SECRET=your_client_secret
-    GOOGLE_REDIRECT_URL=http://localhost:3000/api/auth/google/callback
+    GOOGLE_REDIRECT_URL=http://localhost:3300/api/auth/google/callback
     ```
 
 ## Running the Application
@@ -44,7 +44,7 @@ This example demonstrates how to implement Google OAuth2 authentication in a Fib
     go run main.go
     ```
 
-2. The server will start on `http://localhost:3000`.
+2. The server will start on `http://localhost:3300`.
 
 ## Endpoints
 
@@ -57,12 +57,12 @@ This example demonstrates how to implement Google OAuth2 authentication in a Fib
 
 ### Redirect to Google Login
 ```sh
-curl -X GET http://localhost:3000/api/
+curl -X GET http://localhost:3300/api/
 ```
 
 ### Google OAuth2 Callback
 ```sh
-curl -X GET http://localhost:3000/api/auth/google/callback?state=state&code=code
+curl -X GET http://localhost:3300/api/auth/google/callback?state=state&code=code
 ```
 
 ## Packages Used

--- a/oauth2-google/auth/auth.go
+++ b/oauth2-google/auth/auth.go
@@ -17,9 +17,9 @@ import (
 // ConfigGoogle to set config of oauth
 func ConfigGoogle() *oauth2.Config {
 	conf := &oauth2.Config{
-		ClientID:     config.Config("Client"),
-		ClientSecret: config.Config("Secret"),
-		RedirectURL:  config.Config("redirect_url"),
+		ClientID:     config.Config("GOOGLE_CLIENT_ID"),
+		ClientSecret: config.Config("GOOGLE_CLIENT_SECRET"),
+		RedirectURL:  config.Config("GOOGLE_REDIRECT_URL"),
 		Scopes: []string{
 			"https://www.googleapis.com/auth/userinfo.email",
 		}, // you can use other scopes to get more data

--- a/oauth2-google/example.env
+++ b/oauth2-google/example.env
@@ -1,3 +1,3 @@
-Client = "" ## google client , get it from https://console.developers.google.com/
-Secret = "" # secret of the client 
-redirect_url = "" # redirect url you added in your google oauth api, make sure the url is same including the port, should match the route of callback 
+GOOGLE_CLIENT_ID = "" ## google client , get it from https://console.developers.google.com/
+GOOGLE_CLIENT_SECRET = "" # secret of the client
+GOOGLE_REDIRECT_URL = "" # redirect url you added in your google oauth api, make sure the url is same including the port, should match the route of callback

--- a/oauth2-google/example.env
+++ b/oauth2-google/example.env
@@ -1,3 +1,4 @@
+APP_PORT = "3300" ## port on which the app will run
 GOOGLE_CLIENT_ID = "" ## google client , get it from https://console.developers.google.com/
 GOOGLE_CLIENT_SECRET = "" # secret of the client
 GOOGLE_REDIRECT_URL = "" # redirect url you added in your google oauth api, make sure the url is same including the port, should match the route of callback

--- a/oauth2-google/main.go
+++ b/oauth2-google/main.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"log"
+
+	"fiber-oauth-google/config"
 	"fiber-oauth-google/router"
 
 	"github.com/gofiber/fiber/v2"
@@ -9,7 +12,13 @@ import (
 
 func main() {
 	godotenv.Load()
+
+	port := config.Config("APP_PORT")
+	if port == "" {
+		port = "3300"
+	}
+
 	app := fiber.New()
 	router.Routes(app)
-	app.Listen(":3300")
+	log.Fatal(app.Listen(":" + port))
 }


### PR DESCRIPTION
- Updated: Documentation to match default port set by the recipe
- Updated: Example `env` file and `auth.go` to match documentation
- Updated: Fatal log when server is unable to listen on the selected port
- Added: Additional env variable to make port configurable, with default and fallback to match previous documentation

Fixes #2866

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Documentation**
  - Updated setup instructions to reflect the new server configuration now running on port 3300, including revised redirect URLs.

- **Chores**
  - Standardized configuration keys and sample environment variables for OAuth2 integration.
  - Enhanced error logging to better capture startup issues.
  - Introduced a new environment variable `APP_PORT` for clearer port configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->