### PR TITLE
feat: Improve SSE example to demonstrate user-defined publishing

### DIFF
--- a/sse/README.md
+++ b/sse/README.md
@@ -49,7 +49,7 @@ Server-Sent Events (SSE) allow servers to push updates to the client over a sing
 
 ## Example Usage
 
-By default the example will run on port `3000`, this can be changed by modifying the `appPort` constant in `main.go`
+By default, the example will run on port `3000`; this can be changed by modifying the `appPort` constant in `main.go`
 
 1. Open your browser and navigate to `http://localhost:3000`.
 2. The client will automatically connect to the SSE endpoint and start receiving updates from the server.
@@ -68,7 +68,7 @@ To send a custom message, send a `PUT` request to the `/publish` endpoint in the
 Messages sent to the `/publish` endpoint will be added to a queue that is read from in FIFO order. You can test this
 by using curl in an iterator
 
-If you are using bash/zsh:
+If you are using the Bash or Zsh shell:
 ```sh
 for i in {1..10}; do
   curl -X PUT -H 'Content-type: application/json' --data "{\"message\":\"SSE TEST $i\"}" http://localhost:3000/publish

--- a/sse/README.md
+++ b/sse/README.md
@@ -56,6 +56,7 @@ By default the example will run on port `3000`, this can be changed by modifying
 3. The `/sse` endpoint will publish the current time to the client every two seconds
 
 ### Custom Messages
+
 To send a custom message, send a `PUT` request to the `/publish` endpoint in the following JSON format
 
 ```json
@@ -90,10 +91,6 @@ and no user-published messages are left, `/sse` will return to it's standard beh
 ### `main.go`
 
 The main Go file sets up the Fiber application and handles the SSE connections. It includes the necessary configuration to send events to the client.
-
-### `index.html`
-
-The HTML file provides a simple user interface to connect to the SSE endpoint and display the received messages.
 
 ## Additional Information
 

--- a/sse/README.md
+++ b/sse/README.md
@@ -45,11 +45,45 @@ Server-Sent Events (SSE) allow servers to push updates to the client over a sing
 
 - **GET /**: Index page
 - **GET /sse**: SSE route
+- **PUT /publish**: Send messages via SSE
 
 ## Example Usage
 
+By default the example will run on port `3000`, this can be changed by modifying the `appPort` constant in `main.go`
+
 1. Open your browser and navigate to `http://localhost:3000`.
 2. The client will automatically connect to the SSE endpoint and start receiving updates from the server.
+3. The `/sse` endpoint will publish the current time to the client every two seconds
+
+### Custom Messages
+To send a custom message, send a `PUT` request to the `/publish` endpoint in the following JSON format
+
+```json
+{
+  "message": "Hello, World!"
+}
+```
+
+Messages sent to the `/publish` endpoint will be added to a queue that is read from in FIFO order. You can test this
+by using curl in an iterator
+
+If you are using bash/zsh:
+```sh
+for i in {1..10}; do
+  curl -X PUT -H 'Content-type: application/json' --data "{\"message\":\"SSE TEST $i\"}" http://localhost:3000/publish
+done
+```
+
+If you are using fish:
+```sh
+for i in (seq 1 10)
+  curl -X PUT -H 'Content-type: application/json' --data "{\"message\":\"SSE TEST $i\"}" http://localhost:3000/publish
+end
+```
+
+Once published, your added messages will begin appearing in the output at `http://localhost:3000`. Once the queue is empty
+and no user-published messages are left, `/sse` will return to it's standard behavior of displaying the current time.
+
 
 ## Code Overview
 

--- a/sse/main.go
+++ b/sse/main.go
@@ -14,7 +14,7 @@ import (
 )
 
 // appPort is the port that the server will listen on
-const appPort = "7331"
+const appPort = "3000"
 
 // index is the HTML template that will be served to the client on the index page (`/`)
 const index = `<!DOCTYPE html>


### PR DESCRIPTION
Low-hanging-fruit in issue #1533 (from Jun 15, 2023)

## Fixes

### CORS panic

Existing implementation would cause a panic due to `AllowCredentials: true` and `AllowCredentials: "*"` being set together in the CORS configuration object

```sh
❯ go run main.go
panic: [CORS] Insecure setup, 'AllowCredentials' is set to true, and 'AllowCredentials' is set to a wildcard.

goroutine 1 [running]:
github.com/gofiber/fiber/v2/middleware/cors.New({0x1400007ced8?, 0x0?, 0x1000001007ff740?})
/work/.gopath/pkg/mod/github.com/gofiber/fiber/v2@v2.52.5/middleware/cors/cors.go:113 +0x6f0
main.main()
/work/go-fiber-recipes/sse/main.go:41 +0x84
exit status 2
```

## Improvements

### Server Port

Previously the port was hardcoded to "3000" in both the Fiber setup, and the html returned on route `/`, if this port was in use, the server would fail to start. 

A new constant `appPort` has been added at the top of the `main.go` file to allow for this to be changed by the user, when needed. It is still set to "3000" by default.

### Index HTML

The documentation previously referenced a `index.html` file, but the example had the contents as an in-line byte slice.

The documentation has been updated to remove the reference to the non-existent `index.html` file and the existing HTML has been updated so that we can use the dynamically set port.

> [!NOTE]
> As this is a very minor use of templating, to simply set the port, I've added this using the in-built `text/template` system, rather than going overkill and using one of the external templating engines supported by Fiber.

## Additions

### Publish route

A new `PUT` route has been added at `/publish` to display an example of how user defined messages can be sent over SSE.

Documentation on how to use this route, and how it works has been added to `README.md`

Messages can be published to this queue by sending them in a json formatted `PUT` request

e.g.

```json
{
  "message": "Hello, World!"
}
```

If a message is accepted, it is added to `sseMessageQueue`, if this slice is not empty, it will be read in FIFO order, to send messages to the client. If there are no remaining messages in the queue, it will revert to the default behavior of printing the current time.

Documentation has been added to let users test this message queueing behavior.

**Example output**

```
Message: 1 - the time is 2025-03-24 21:24:48.801204 +0000 GMT m=+2.759782418
Message: 2 - the time is 2025-03-24 21:24:50.802182 +0000 GMT m=+4.760755751
Message: 3 - the time is 2025-03-24 21:24:52.803343 +0000 GMT m=+6.761912751
Message: 4 - the time is 2025-03-24 21:24:54.804524 +0000 GMT m=+8.763088584
Message: 5 - the time is 2025-03-24 21:24:56.805747 +0000 GMT m=+10.764307251
Message: 6 - the time is 2025-03-24 21:24:58.806713 +0000 GMT m=+12.765268959
Message: 7 - message recieved: SSE TEST 1
Message: 8 - message recieved: SSE TEST 2
Message: 9 - message recieved: SSE TEST 3
Message: 10 - message recieved: SSE TEST 4
Message: 11 - message recieved: SSE TEST 5
Message: 12 - message recieved: SSE TEST 6
Message: 13 - message recieved: SSE TEST 7
Message: 14 - message recieved: SSE TEST 8
Message: 15 - message recieved: SSE TEST 9
Message: 16 - message recieved: SSE TEST 10
Message: 17 - the time is 2025-03-24 21:25:20.82329 +0000 GMT m=+34.781796334
Message: 18 - the time is 2025-03-24 21:25:22.824507 +0000 GMT m=+36.783008918
Message: 19 - the time is 2025-03-24 21:25:24.825666 +0000 GMT m=+38.784162751
Message: 20 - the time is 2025-03-24 21:25:26.82687 +0000 GMT m=+40.785362709
```

---

resolves #1533

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new API endpoint for publishing messages via Server-Sent Events (SSE) using PUT requests.
  - Updated documentation with instructions and examples (using curl in various shells) for testing the new message publishing functionality.
  - Enhanced the message streaming behavior to process queued messages in FIFO order, reverting to regular time updates when no pending messages remain.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->