### PR TITLE
🧹 chore: Cleanup Docker images

### DIFF
--- a/auth-docker-postgres-jwt/Dockerfile
+++ b/auth-docker-postgres-jwt/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24@sha256:d9db32125db0c3a680cfb7a1afcaefb89c898a075ec148fdc2f0f646cc2ed509
+FROM golang:1.24
 
 # Enviroment variable
 WORKDIR /usr/src/some-api

--- a/auth-docker-postgres-jwt/docker-compose.yml
+++ b/auth-docker-postgres-jwt/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   web:
     build: .

--- a/clean-code/docker-compose.yml
+++ b/clean-code/docker-compose.yml
@@ -15,7 +15,7 @@ services:
 
   example_db:
     container_name: example_db
-    image: postgres:17.1-alpine
+    image: postgres:17-alpine
     environment:
       - POSTGRES_DB=example
       - POSTGRES_USER=postgres

--- a/colly-gorm/docker-compose.yml
+++ b/colly-gorm/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   scraper_app:
     container_name: scraper_app
@@ -15,7 +14,7 @@ services:
       - colly_db
 
   colly_db:
-    image: postgres:14.1-alpine
+    image: postgres:14-alpine
     container_name: colly_db
     ports:
       - 5435:5432

--- a/docker-mariadb-clean-arch/Dockerfile
+++ b/docker-mariadb-clean-arch/Dockerfile
@@ -1,5 +1,5 @@
 # Get Go image from DockerHub.
-FROM golang:1.24@sha256:d9db32125db0c3a680cfb7a1afcaefb89c898a075ec148fdc2f0f646cc2ed509 AS api
+FROM golang:1.24 AS api
 
 # Set working directory.
 WORKDIR /compiler

--- a/docker-nginx-loadbalancer/docker-compose.yml
+++ b/docker-nginx-loadbalancer/docker-compose.yml
@@ -1,6 +1,3 @@
-version: '3.3'
-
-#services describe the containers that will start
 services:
   # api is the container name for our Go API
   api:
@@ -19,8 +16,8 @@ services:
       replicas: 5
   # nginx container
   nginx:
-    # specifies the latest stable alpine nginx image
-    image: nginx:stable-alpine
+    # specifies the latest stable nginx image
+    image: nginx:stable
     # Connects the conf file of the container to the conf file in our folder
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro

--- a/envoy-extauthz/docker-compose.yaml
+++ b/envoy-extauthz/docker-compose.yaml
@@ -1,6 +1,4 @@
-version: "3.7"
 services:
-
   fiber_app:
     build:
       context: ./app

--- a/gcloud-firebase/Dockerfile
+++ b/gcloud-firebase/Dockerfile
@@ -1,7 +1,7 @@
 # Use the offical Golang image to create a build artifact.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
-FROM golang:1.24@sha256:d9db32125db0c3a680cfb7a1afcaefb89c898a075ec148fdc2f0f646cc2ed509 as builder
+FROM golang:1.24 as builder
 
 # Copy local code to the container image.
 WORKDIR /go/app

--- a/gcloud/Dockerfile
+++ b/gcloud/Dockerfile
@@ -1,7 +1,7 @@
 # Use the offical Golang image to create a build artifact.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
-FROM golang:1.24@sha256:d9db32125db0c3a680cfb7a1afcaefb89c898a075ec148fdc2f0f646cc2ed509 as builder
+FROM golang:1.24 as builder
 
 # Copy local code to the container image.
 WORKDIR /go/app

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -89,7 +89,7 @@ func main() {
 Here is an example `Dockerfile` for the application:
 
 ```Dockerfile
-FROM golang:1.20-alpine
+FROM golang:1.24
 
 WORKDIR /app
 

--- a/rabbitmq/worker/Dockerfile
+++ b/rabbitmq/worker/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM golang:1.24-alpine@sha256:7772cb5322baa875edd74705556d08f0eeca7b9c4b5367754ce3f2f00041ccee AS builder
+FROM golang:1.24 AS builder
 
 # Move to working directory (/build).
 WORKDIR /build

--- a/react-router/Dockerfile
+++ b/react-router/Dockerfile
@@ -1,5 +1,5 @@
 # First stage: Get Golang image from DockerHub.
-FROM golang:1.24@sha256:d9db32125db0c3a680cfb7a1afcaefb89c898a075ec148fdc2f0f646cc2ed509 AS backend-builder
+FROM golang:1.24 AS backend-builder
 
 # Label this container.
 LABEL appname="React App Fiber"


### PR DESCRIPTION
- Remove sha256 hashes from example Docker images
- Remove `version`  from docker-compose files
- Remove `patch` versions from Docker tags

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated Dockerfiles across multiple components to use the generic golang:1.24 base image tag instead of digest-pinned versions.
	- Updated documentation example to reference golang:1.24.
	- Changed one Dockerfile to use the default Go image instead of the Alpine-based variant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->