### PR TITLE
docs: add missing DB_HOST variable to .env example in README

### DIFF
--- a/auth-jwt/README.md
+++ b/auth-jwt/README.md
@@ -33,6 +33,7 @@ This project provides a starting point for building a web application with user 
     DB_USER=example_user
     DB_PASSWORD=example_password
     DB_NAME=example_db
+    DB_HOST=localhost
     SECRET=example_secret
     ```
 


### PR DESCRIPTION
### Summary

This PR fixes a small issue in the README where the `.env` example is missing the `DB_HOST` variable. Without this variable, the application fails to start due to an undefined database host.

### Context

Previously, it might have defaulted to `localhost`, but with recent changes (or in certain environments), this fallback no longer works, leading to connection errors during startup.

### Fix

Added the following line to the `.env` example in the README:

```env
DB_HOST=localhost

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated setup instructions to include the `DB_HOST` environment variable in the configuration steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->