### PR TITLE
NewProductService should return the Service interface, not the private service type

### DIFF
--- a/hexagonal/service/logic.go
+++ b/hexagonal/service/logic.go
@@ -6,7 +6,7 @@ type service struct {
 	productRepo domain.Repository
 }
 
-// NewProductService a service struct that attaches to a repository via the Repository interface
+// NewProductService returns a domain.Service backed by the provided domain.Repository.
 func NewProductService(productRepo domain.Repository) domain.Service {
 	return &service{productRepo: productRepo}
 }


### PR DESCRIPTION
I noticed this with IDE warning:
> Exported function with the unexported return type

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal service construction updated to return an abstract interface rather than a concrete type to improve modularity.
  * No changes to user-facing behavior or UI; functionality remains unchanged.
  * No action required from users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->