### PR TITLE
fix(svelte-netlify): resolve Fiber v2 to the patched release in the module graph

### DIFF
--- a/svelte-netlify/go.mod
+++ b/svelte-netlify/go.mod
@@ -26,3 +26,9 @@ require (
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/text v0.40.0 // indirect
 )
+
+// aws-lambda-go-api-proxy v0.16.2 pins github.com/gofiber/fiber/v2 v2.52.1 in its
+// own go.mod. That version never reaches this build -- this recipe uses Fiber v3
+// and only imports the proxy's /core package -- but it still shows up in the
+// module graph. Force the patched release so scanners resolve v2.52.14.
+replace github.com/gofiber/fiber/v2 => github.com/gofiber/fiber/v2 v2.52.14

--- a/svelte-netlify/go.mod
+++ b/svelte-netlify/go.mod
@@ -30,5 +30,11 @@ require (
 // aws-lambda-go-api-proxy v0.16.2 pins github.com/gofiber/fiber/v2 v2.52.1 in its
 // own go.mod. That version never reaches this build -- this recipe uses Fiber v3
 // and only imports the proxy's /core package -- but it still shows up in the
-// module graph. Force the patched release so scanners resolve v2.52.14.
-replace github.com/gofiber/fiber/v2 => github.com/gofiber/fiber/v2 v2.52.14
+// module graph. Pin that exact version to the patched release so scanners
+// resolve v2.52.14.
+//
+// Scoped to v2.52.1 on purpose: an unversioned replace would also downgrade a
+// legitimately newer Fiber v2 if some future dependency required one. If the
+// proxy changes its pin, this stops applying and the new version shows up in
+// scans again, which is the behaviour we want.
+replace github.com/gofiber/fiber/v2 v2.52.1 => github.com/gofiber/fiber/v2 v2.52.14


### PR DESCRIPTION
Follow-up to #5290, covering the Fiber v2 advisories specifically.

## Where Fiber v2 actually is

I resolved the full module graph of all 91 Go modules (`go list -m all`, 899 unique versions) and checked every one against OSV. Fiber v2 appears in exactly three places:

| Module | Version | Status |
|---|---|---|
| `v2/aws-sam/app` | v2.52.14 (direct) | latest release, no open advisories |
| `openapi` | v2.52.14 (indirect) | latest release, no open advisories |
| `svelte-netlify` | **v2.52.1** (module graph only) | affected, addressed here |

Everything else in the repository is on Fiber **v3.4.0**, which is also the latest and carries no advisories.

## svelte-netlify

v2.52.1 reaches the graph through `github.com/awslabs/aws-lambda-go-api-proxy v0.16.2`, which pins `github.com/gofiber/fiber/v2 v2.52.1` in its own `go.mod`. v0.16.2 is the **latest** release of that library, so there is no upstream bump to take.

v2.52.1 is affected by eleven advisories, two of them critical:

- [GHSA-98j2-3j3p-fw2v](https://github.com/advisories/GHSA-98j2-3j3p-fw2v), session middleware token injection (Critical)
- [GHSA-68rr-p4fp-j59v](https://github.com/advisories/GHSA-68rr-p4fp-j59v), insecure `utils.UUIDv4()` fallback (Critical)
- [GHSA-qx2q-88mx-vhg7](https://github.com/advisories/GHSA-qx2q-88mx-vhg7) (High), plus 8 moderate

**None of them apply to this recipe.** It uses Fiber v3 throughout and imports only the proxy's `/core` package, which does not pull in Fiber v2. Concretely:

- `github.com/gofiber/fiber/v2` is not listed in `svelte-netlify/go.mod`
- it has **no entry in `svelte-netlify/go.sum`**, so the toolchain never downloads or compiles it
- `go mod why -m github.com/gofiber/fiber/v2` reports `(main module does not need module github.com/gofiber/fiber/v2)`

It is a module-graph artifact, not a dependency of the build.

## The fix

It is still reported by anything that resolves the module graph rather than the build list, so this pins it to the patched **v2.52.14**.

A plain indirect `require` does not work here. I tried it first, and `go mod tidy` drops it again because no package in the main module needs it:

```
after go get:       github.com/gofiber/fiber/v2 v2.52.14
after go mod tidy:  github.com/gofiber/fiber/v2 v2.52.1
```

A `replace` survives `tidy` and selects v2.52.14 without changing what is compiled:

```
github.com/gofiber/fiber/v2 v2.52.1 => github.com/gofiber/fiber/v2 v2.52.14
```

All three Fiber v2 sites now resolve to v2.52.14.

## Verification

- `go build ./...` passes in `svelte-netlify`
- `go mod tidy` leaves the `replace` in place and does not otherwise alter `go.mod`
- Re-resolved graph confirms v2.52.14 in all three modules

If you would rather not carry a `replace` for a dependency that is never compiled, the alternative is to dismiss the alert as "vulnerable code is not actually used". Happy to drop this PR in that case.