### PR TITLE
ci: scan every manifest against OSV on pull requests

### DIFF
--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -41,10 +41,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: stable
           cache: false

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -1,0 +1,58 @@
+name: OSV Scanner
+
+# Catches vulnerable dependency versions at PR time instead of months later on
+# the Security tab.
+#
+# Dependabot alerts are necessary but not sufficient here: they only tell you
+# about drift after an advisory lands, and only for ecosystems and manifests it
+# is configured to see. This job resolves every manifest in the repository --
+# go.mod, pnpm-lock.yaml, package-lock.json and bun.lock -- against OSV.dev on
+# every pull request, so a lockfile that quietly falls behind fails a check
+# instead of accumulating alerts.
+#
+# Accepted findings live in osv-scanner.toml.
+
+on:
+  push:
+    branches:
+      - master
+      - main
+    paths-ignore:
+      - "**.md"
+  pull_request:
+    paths-ignore:
+      - "**.md"
+  schedule:
+    # weekly, so newly published advisories against unchanged manifests surface
+    # on their own rather than waiting for the next unrelated pull request
+    - cron: '23 5 * * 1'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    name: Scan dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: stable
+          cache: false
+
+      - name: Install osv-scanner
+        run: go install github.com/google/osv-scanner/v2/cmd/osv-scanner@v2.4.0
+
+      - name: Scan
+        # `scan source -r` walks every manifest and lockfile in the tree. It
+        # exits non-zero when anything not listed in osv-scanner.toml is found.
+        run: osv-scanner scan source -r --config=osv-scanner.toml .

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,0 +1,23 @@
+# Accepted findings for the OSV scan in .github/workflows/osv-scanner.yml.
+#
+# Only add an entry here when an advisory has no fixed version available, or
+# when the affected code is provably unreachable. Anything that can simply be
+# upgraded should be upgraded instead -- an ignore entry that hides a fixable
+# advisory is how alerts end up sitting open for months.
+#
+# Please leave a reason and, where it makes sense, a review date.
+
+[[IgnoredVulns]]
+id = "GO-2026-5932"
+reason = """
+"The golang.org/x/crypto/openpgp package is unmaintained, unsafe by design, and
+has known security issues". There is no fixed version -- the advisory covers all
+releases of golang.org/x/crypto, and v0.54.0 is the latest.
+
+The advisory is scoped to the golang.org/x/crypto/openpgp import paths, and
+nothing in this repository imports them; x/crypto is pulled in transitively by
+Fiber. It also has no GHSA identifier, so it is a govulncheck/OSV-only entry.
+
+Revisit if any recipe ever imports golang.org/x/crypto/openpgp -- at that point
+it should move to github.com/ProtonMail/go-crypto/openpgp instead.
+"""


### PR DESCRIPTION
> **Stacked on #5297.** Base is `claude/cloudflare-workers-bun-security`, so this diff shows only the CI change. Merging #5297 first retargets this to `master` automatically.
>
> Stacking is what makes this check meaningful here: on `master` alone it fails on the four `cloudflare-workers/bun.lock` packages #5297 fixes. On top of #5297 it passes clean, so the check is green from the moment it lands.

Follow-up to #5290. This is the piece that stops the alerts from coming back rather than fixing another round of them.

## Why alerts kept reappearing

Dependabot alerts are necessary but not sufficient here. They report drift **after** an advisory lands, and only for the ecosystems and manifests Dependabot is configured to see. Both limits bit this repository:

- `cloudflare-workers/bun.lock` had **no matching `package-ecosystem` entry at all**, invisible for months (#5297)
- an `allow: dependency-type: "direct"` filter hid **every transitive npm advisory** (fixed in #5290)
- pnpm's auto-installed peer dependencies (`esbuild`, `yaml`, `@sveltejs/vite-plugin-svelte`) were never re-resolved once pinned

Nothing in CI would have caught any of those. The manifests sat frozen while the advisory database moved.

## What this adds

A check that resolves **every** manifest in the tree (`go.mod`, `pnpm-lock.yaml`, `package-lock.json` and `bun.lock`) against [OSV.dev](https://osv.dev) on each pull request. A lockfile that quietly falls behind now fails a check instead of accumulating alerts nobody looks at.

It also runs weekly, so advisories published against *unchanged* manifests surface on their own rather than waiting for the next unrelated PR. That case is the one Dependabot handles worst and the one that produced most of the recent noise.

`osv-scanner` is pinned to **v2.4.0** and installed via `go install`, so the version is reproducible and there is no action tag to drift.

## Accepted findings

`osv-scanner.toml` holds the exceptions, currently exactly one:

| ID | Reason |
|---|---|
| `GO-2026-5932` | "golang.org/x/crypto/openpgp is unmaintained." No fixed version (covers all releases, v0.54.0 is latest), no GHSA identifier, and scoped to import paths nothing here uses. |

Keeping exceptions in a file that has to be edited to grow makes each accepted risk a deliberate decision, rather than an alert that silently stays open. The file's header asks for a reason and warns against ignoring anything that could simply be upgraded.

## Verification

Run locally against this tree:

- on `master` alone: reports `hono@4.11.9` (28), `undici@7.18.2` (11), `ws@8.18.0` (2), `sharp@0.34.5` (1), exit 1
- on this stacked branch (with #5297): `No issues found`, 88 filtered (the x/crypto entry across 88 modules), exit 0

It independently reproduced the findings from #5290 and #5297 without being given them, and correctly does **not** flag the Fiber v2 module-graph entry from #5300, since that one never reaches the build list.