### PR TITLE
fix(docker-mariadb-clean-arch): bound data layer calls with a request context

### DIFF
--- a/docker-mariadb-clean-arch/internal/city/handler.go
+++ b/docker-mariadb-clean-arch/internal/city/handler.go
@@ -2,11 +2,18 @@ package city
 
 import (
 	"context"
+	"time"
 
 	"docker-mariadb-clean-arch/internal/auth"
 
 	"github.com/gofiber/fiber/v3"
 )
+
+// requestTimeout bounds how long a single request may spend in the data
+// layer. Without it a hung query would block the handler indefinitely,
+// since the request context alone is only cancelled when the client
+// disconnects.
+const requestTimeout = 10 * time.Second
 
 // We will inject our dependency - the service - here.
 type CityHandler struct {
@@ -37,7 +44,10 @@ func NewCityHandler(cityRoute fiber.Router, cs CityService) {
 // Handler to get all cities.
 func (h *CityHandler) getCities(c fiber.Ctx) error {
 	// Get all cities.
-	cities, err := h.cityService.FetchCities(context.Background())
+	ctx, cancel := context.WithTimeout(c.Context(), requestTimeout)
+	defer cancel()
+
+	cities, err := h.cityService.FetchCities(ctx)
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(&fiber.Map{
 			"status":  "fail",
@@ -64,7 +74,10 @@ func (h *CityHandler) getCity(c fiber.Ctx) error {
 	}
 
 	// Get one city.
-	city, err := h.cityService.FetchCity(context.Background(), targetedCityID)
+	ctx, cancel := context.WithTimeout(c.Context(), requestTimeout)
+	defer cancel()
+
+	city, err := h.cityService.FetchCity(ctx, targetedCityID)
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(&fiber.Map{
 			"status":  "fail",
@@ -94,7 +107,10 @@ func (h *CityHandler) createCity(c fiber.Ctx) error {
 	}
 
 	// Create one city.
-	err := h.cityService.BuildCity(context.Background(), city, currentUserID)
+	ctx, cancel := context.WithTimeout(c.Context(), requestTimeout)
+	defer cancel()
+
+	err := h.cityService.BuildCity(ctx, city, currentUserID)
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(&fiber.Map{
 			"status":  "fail",
@@ -125,7 +141,10 @@ func (h *CityHandler) updateCity(c fiber.Ctx) error {
 	}
 
 	// Update one city.
-	err := h.cityService.ModifyCity(context.Background(), targetedCityID, city, currentUserID)
+	ctx, cancel := context.WithTimeout(c.Context(), requestTimeout)
+	defer cancel()
+
+	err := h.cityService.ModifyCity(ctx, targetedCityID, city, currentUserID)
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(&fiber.Map{
 			"status":  "fail",
@@ -146,7 +165,10 @@ func (h *CityHandler) deleteCity(c fiber.Ctx) error {
 	targetedCityID := c.Locals("cityID").(int)
 
 	// Delete one city.
-	err := h.cityService.DestroyCity(context.Background(), targetedCityID)
+	ctx, cancel := context.WithTimeout(c.Context(), requestTimeout)
+	defer cancel()
+
+	err := h.cityService.DestroyCity(ctx, targetedCityID)
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(&fiber.Map{
 			"status":  "fail",

--- a/docker-mariadb-clean-arch/internal/city/handler.go
+++ b/docker-mariadb-clean-arch/internal/city/handler.go
@@ -9,10 +9,11 @@ import (
 	"github.com/gofiber/fiber/v3"
 )
 
-// requestTimeout bounds how long a single request may spend in the data
-// layer. Without it a hung query would block the handler indefinitely,
-// since the request context alone is only cancelled when the client
-// disconnects.
+// requestTimeout bounds a single data layer call, not a whole request.
+// Routes that run the existence middleware before the handler perform two
+// independent calls and can therefore wait up to twice this long in total.
+// Without it a hung query would block indefinitely, since the request
+// context alone is only cancelled when the client disconnects.
 const requestTimeout = 10 * time.Second
 
 // We will inject our dependency - the service - here.

--- a/docker-mariadb-clean-arch/internal/city/middleware.go
+++ b/docker-mariadb-clean-arch/internal/city/middleware.go
@@ -18,10 +18,13 @@ func (h *CityHandler) checkIfCityExistsMiddleware(c fiber.Ctx) error {
 	}
 
 	// Check if city exists.
+	// cancel() is called directly instead of deferred: this is middleware, so
+	// a deferred call would only run after c.Next() returns and would keep the
+	// timer alive for the whole downstream chain. The row is fully scanned
+	// before the call returns, so releasing the context here is safe.
 	ctx, cancel := context.WithTimeout(c.Context(), requestTimeout)
-	defer cancel()
-
 	searchedCity, err := h.cityService.FetchCity(ctx, targetedCityID)
+	cancel()
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(&fiber.Map{
 			"status":  "fail",

--- a/docker-mariadb-clean-arch/internal/city/middleware.go
+++ b/docker-mariadb-clean-arch/internal/city/middleware.go
@@ -18,7 +18,10 @@ func (h *CityHandler) checkIfCityExistsMiddleware(c fiber.Ctx) error {
 	}
 
 	// Check if city exists.
-	searchedCity, err := h.cityService.FetchCity(context.Background(), targetedCityID)
+	ctx, cancel := context.WithTimeout(c.Context(), requestTimeout)
+	defer cancel()
+
+	searchedCity, err := h.cityService.FetchCity(ctx, targetedCityID)
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(&fiber.Map{
 			"status":  "fail",

--- a/docker-mariadb-clean-arch/internal/city/repository.go
+++ b/docker-mariadb-clean-arch/internal/city/repository.go
@@ -61,6 +61,12 @@ func (r *mariaDBRepository) GetCities(ctx context.Context) (*[]CityAndUser, erro
 		cities = append(cities, *city)
 	}
 
+	// res.Next() also stops on a cancelled context, so without this the
+	// caller would receive a partial slice and a nil error.
+	if err := res.Err(); err != nil {
+		return nil, err
+	}
+
 	return &cities, nil
 }
 

--- a/docker-mariadb-clean-arch/internal/user/handler.go
+++ b/docker-mariadb-clean-arch/internal/user/handler.go
@@ -2,11 +2,18 @@ package user
 
 import (
 	"context"
+	"time"
 
 	"github.com/gofiber/fiber/v3"
 )
 
 // Represents our handler with our use-case / service.
+// requestTimeout bounds how long a single request may spend in the data
+// layer. Without it a hung query would block the handler indefinitely,
+// since the request context alone is only cancelled when the client
+// disconnects.
+const requestTimeout = 10 * time.Second
+
 type UserHandler struct {
 	userService UserService
 }
@@ -31,7 +38,10 @@ func NewUserHandler(userRoute fiber.Router, us UserService) {
 // Gets all users.
 func (h *UserHandler) getUsers(c fiber.Ctx) error {
 	// Get all users.
-	users, err := h.userService.GetUsers(context.Background())
+	ctx, cancel := context.WithTimeout(c.Context(), requestTimeout)
+	defer cancel()
+
+	users, err := h.userService.GetUsers(ctx)
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(&fiber.Map{
 			"status":  "fail",
@@ -58,7 +68,10 @@ func (h *UserHandler) getUser(c fiber.Ctx) error {
 	}
 
 	// Get one user.
-	user, err := h.userService.GetUser(context.Background(), targetedUserID)
+	ctx, cancel := context.WithTimeout(c.Context(), requestTimeout)
+	defer cancel()
+
+	user, err := h.userService.GetUser(ctx, targetedUserID)
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(&fiber.Map{
 			"status":  "fail",
@@ -87,7 +100,10 @@ func (h *UserHandler) createUser(c fiber.Ctx) error {
 	}
 
 	// Create one user.
-	err := h.userService.CreateUser(context.Background(), user)
+	ctx, cancel := context.WithTimeout(c.Context(), requestTimeout)
+	defer cancel()
+
+	err := h.userService.CreateUser(ctx, user)
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(&fiber.Map{
 			"status":  "fail",
@@ -117,7 +133,10 @@ func (h *UserHandler) updateUser(c fiber.Ctx) error {
 	}
 
 	// Update one user.
-	err := h.userService.UpdateUser(context.Background(), targetedUserID, user)
+	ctx, cancel := context.WithTimeout(c.Context(), requestTimeout)
+	defer cancel()
+
+	err := h.userService.UpdateUser(ctx, targetedUserID, user)
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(&fiber.Map{
 			"status":  "fail",
@@ -138,7 +157,10 @@ func (h *UserHandler) deleteUser(c fiber.Ctx) error {
 	targetedUserID := c.Locals("userID").(int)
 
 	// Delete one user.
-	err := h.userService.DeleteUser(context.Background(), targetedUserID)
+	ctx, cancel := context.WithTimeout(c.Context(), requestTimeout)
+	defer cancel()
+
+	err := h.userService.DeleteUser(ctx, targetedUserID)
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(&fiber.Map{
 			"status":  "fail",

--- a/docker-mariadb-clean-arch/internal/user/handler.go
+++ b/docker-mariadb-clean-arch/internal/user/handler.go
@@ -8,10 +8,11 @@ import (
 )
 
 // Represents our handler with our use-case / service.
-// requestTimeout bounds how long a single request may spend in the data
-// layer. Without it a hung query would block the handler indefinitely,
-// since the request context alone is only cancelled when the client
-// disconnects.
+// requestTimeout bounds a single data layer call, not a whole request.
+// Routes that run the existence middleware before the handler perform two
+// independent calls and can therefore wait up to twice this long in total.
+// Without it a hung query would block indefinitely, since the request
+// context alone is only cancelled when the client disconnects.
 const requestTimeout = 10 * time.Second
 
 type UserHandler struct {

--- a/docker-mariadb-clean-arch/internal/user/middleware.go
+++ b/docker-mariadb-clean-arch/internal/user/middleware.go
@@ -18,7 +18,10 @@ func (h *UserHandler) checkIfUserExistsMiddleware(c fiber.Ctx) error {
 	}
 
 	// Check if user exists.
-	searchedUser, err := h.userService.GetUser(context.Background(), targetedUserID)
+	ctx, cancel := context.WithTimeout(c.Context(), requestTimeout)
+	defer cancel()
+
+	searchedUser, err := h.userService.GetUser(ctx, targetedUserID)
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(&fiber.Map{
 			"status":  "fail",

--- a/docker-mariadb-clean-arch/internal/user/middleware.go
+++ b/docker-mariadb-clean-arch/internal/user/middleware.go
@@ -18,10 +18,13 @@ func (h *UserHandler) checkIfUserExistsMiddleware(c fiber.Ctx) error {
 	}
 
 	// Check if user exists.
+	// cancel() is called directly instead of deferred: this is middleware, so
+	// a deferred call would only run after c.Next() returns and would keep the
+	// timer alive for the whole downstream chain. The row is fully scanned
+	// before the call returns, so releasing the context here is safe.
 	ctx, cancel := context.WithTimeout(c.Context(), requestTimeout)
-	defer cancel()
-
 	searchedUser, err := h.userService.GetUser(ctx, targetedUserID)
+	cancel()
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(&fiber.Map{
 			"status":  "fail",

--- a/docker-mariadb-clean-arch/internal/user/repository.go
+++ b/docker-mariadb-clean-arch/internal/user/repository.go
@@ -53,6 +53,12 @@ func (r *mariaDBRepository) GetUsers(ctx context.Context) (*[]User, error) {
 	}
 
 	// Return all of our users.
+	// res.Next() also stops on a cancelled context, so without this the
+	// caller would receive a partial slice and a nil error.
+	if err := res.Err(); err != nil {
+		return nil, err
+	}
+
 	return &users, nil
 }
 


### PR DESCRIPTION
Closes #2718.

## The problem

Every handler and middleware in this recipe passed `context.Background()` straight through the service into the repository and on to `database/sql`. Nothing ever set a deadline, so a slow or hung query blocked the handler for as long as the driver kept waiting, and a client that disconnected left the query running.

The issue reported this against `context.WithCancel`, which the code used in 2023:

```go
customContext, cancel := context.WithCancel(context.Background())
defer cancel()
```

The reporter was right, and for a sharper reason than they gave. The `cancel` func was deferred but nothing else could ever trigger it, so it cancelled nothing. The call was later simplified to a plain `context.Background()`, which removed even that.

## The fix

All twelve call sites now derive from the request context and add a deadline:

```go
ctx, cancel := context.WithTimeout(c.Context(), requestTimeout)
defer cancel()

cities, err := h.cityService.FetchCities(ctx)
```

This covers both halves of the problem, which a bare `WithTimeout(context.Background(), ...)` would not:

- `c.Context()` is cancelled when the client disconnects, so an abandoned request stops occupying a database connection
- the timeout bounds a query that hangs while the client is still connected

`requestTimeout` is a package level constant in `city` and `user`, set to 10 seconds. Kept per package rather than shared, so the two stay independent as the clean architecture layout intends.

Sites touched: 5 in `city/handler.go`, 1 in `city/middleware.go`, 5 in `user/handler.go`, 1 in `user/middleware.go`.

## On the `wontfix` label

Worth flagging, since it looks like a maintainer decision and is not one. `.github/stale.yml` sets `staleLabel: wontfix`, so the label was applied automatically by the stale bot. All five comments on the issue are bot noise, three welcome-bot and two stale-bot. Nobody ever answered the technical question.

The same applies to #2704, #2705 and #2706, which carry the label for the same reason.

## Verification

- `go build ./...` passes
- `go vet ./...` passes
- no `context.Background()` calls remain anywhere in the recipe

Not exercised: the running stack against MariaDB, which needs the docker-compose environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a 10-second timeout to city and user operations.
  * Requests now stop processing when the client request ends or the timeout is reached.
  * Improved cancellation handling for city and user lookups, creation, updates, and deletions.
  * Query failures encountered while reading city or user results are now reported instead of returning incomplete data as successful responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->