### PR TITLE
Clear stale fiber-envoy-extauthz dependency graph entries

### DIFF
--- a/fiber-envoy-extauthz/app/go.mod
+++ b/fiber-envoy-extauthz/app/go.mod
@@ -1,0 +1,3 @@
+module envoyappstub
+
+go 1.25.0

--- a/fiber-envoy-extauthz/app/main.go
+++ b/fiber-envoy-extauthz/app/main.go
@@ -1,0 +1,15 @@
+// Package main is a placeholder, not a recipe. The real example lives in
+// envoy-extauthz/.
+//
+// Renaming fiber-envoy-extauthz/ to envoy-extauthz/ in d85c8d2 (Nov 2024) left
+// GitHub's dependency graph holding manifests for the old path, frozen on the
+// fiber v2 they pinned back then. Every new fiber v2 advisory still raises
+// alerts against them, and the security update job that would close those
+// alerts aborts with dependency_file_not_found because the path is gone.
+//
+// Re-creating the manifest makes the graph re-scan the path and find a module
+// with no dependencies, which clears the stale fiber v2 entry. This directory
+// is deleted again afterwards, that time as a delete the graph can observe.
+package main
+
+func main() {}

--- a/fiber-envoy-extauthz/authz/go.mod
+++ b/fiber-envoy-extauthz/authz/go.mod
@@ -1,0 +1,3 @@
+module envoyauthzstub
+
+go 1.25.0

--- a/fiber-envoy-extauthz/authz/main.go
+++ b/fiber-envoy-extauthz/authz/main.go
@@ -1,0 +1,15 @@
+// Package main is a placeholder, not a recipe. The real example lives in
+// envoy-extauthz/.
+//
+// Renaming fiber-envoy-extauthz/ to envoy-extauthz/ in d85c8d2 (Nov 2024) left
+// GitHub's dependency graph holding manifests for the old path, frozen on the
+// fiber v2 they pinned back then. Every new fiber v2 advisory still raises
+// alerts against them, and the security update job that would close those
+// alerts aborts with dependency_file_not_found because the path is gone.
+//
+// Re-creating the manifest makes the graph re-scan the path and find a module
+// with no dependencies, which clears the stale fiber v2 entry. This directory
+// is deleted again afterwards, that time as a delete the graph can observe.
+package main
+
+func main() {}


### PR DESCRIPTION
## What does this change?

This adds placeholder `go.mod` files and minimal `main.go` stubs to the old `fiber-envoy-extauthz/` directory paths. These files allow GitHub's dependency graph to re-scan the old paths and recognize them as modules with no dependencies, which clears stale fiber v2 entries that were frozen when the directory was renamed to `envoy-extauthz/` in commit d85c8d2.

The placeholder files will be deleted in a follow-up commit, but this intermediate step ensures GitHub's dependency graph observes the deletion and clears the associated security alerts.

## Related issue

This resolves stale fiber v2 security alerts that persist in GitHub's dependency graph for the old `fiber-envoy-extauthz/` path.

## Anything reviewers should know

These are temporary placeholder files created solely to trigger a dependency graph re-scan. They will be removed in the next commit once the graph has processed this change. The actual example code lives in `envoy-extauthz/`.

https://claude.ai/code/session_01NJjkhXbe4TuGrWXkoCvhs4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added temporary placeholders to support dependency analysis and cleanup workflows.
  * No user-facing features, behavior, or public interfaces changed.
  * No changes are expected in application functionality or runtime experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->